### PR TITLE
Use -Os for speed and -Oz for size on llvm-mos.

### DIFF
--- a/playground/share/llvm-mos/x-cc.sh
+++ b/playground/share/llvm-mos/x-cc.sh
@@ -6,7 +6,7 @@ ifile=${1}; shift
 
 # VERBOSE="-v"
 
-# [ -z "${OPT}" ] && OPT="-O2"
+# [ -z "${OPT}" ] && OPT="-Os"
 
 CFLAGS="${CFLAGS} --target=mos -D__LLVM_MOS__"
 CFLAGS="${CFLAGS} ${VERBOSE}"

--- a/playground/tools/bench-params.lua
+++ b/playground/tools/bench-params.lua
@@ -30,7 +30,7 @@ compilers_make_param_size = {
   ['cc65']        = '-O',
   ['gcc-6502']    = '-O2',
   ['kickc']       = '',
-  ['llvm-mos']    = '-O2',
+  ['llvm-mos']    = '-Oz',
   ['osdk-lcc65']  = '-O2',
   ['sdcc']        = '--opt-code-size',
   ['vbcc']        = '-O=991',
@@ -41,7 +41,7 @@ compilers_make_param_speed = {
   ['cc65']        = '-Oirs',
   ['gcc-6502']    = '-O3',
   ['kickc']       = '',                 -- -Ocoalesce -Oliverangecallpath -Oloophead',
-  ['llvm-mos']    = '-O3',
+  ['llvm-mos']    = '-Os',
   ['osdk-lcc65']  = '-O2',
   ['sdcc']        = '--opt-code-speed', -- --peep-asm --peep-return
   ['vbcc']        = '-O=1023',


### PR DESCRIPTION
This is the usual practice for embedded LLVM targets and represents typical use of llvm-mos, as all SDK targets default to -Os. We haven't really spent any time trying to make -O2 or higher work well, as the default set of optimizations done by LLVM on -O2 and -O3 make very little sense on embedded platforms.

Note that I didn't update the benchmark results, as I didn't have authoritative copies of all the compilers available, and I'm unsure of the methodology used to obtain them. 